### PR TITLE
Fixes progress reporting of AsyncOperation

### DIFF
--- a/Sources/Operation/AsyncOperation.swift
+++ b/Sources/Operation/AsyncOperation.swift
@@ -99,6 +99,9 @@ open class AsyncOperation : Operation {
 	//MARK: Control
 
 	final override public func start() {
+		
+		super.start()
+
 		if isCancelled {
 			state = .finished
 			return


### PR DESCRIPTION
iOS 13 introduced at new .progress property in OperationQueue. The documentation for this property is not so great at the moment. But NSOperation.h states that "operations that override start and do not invoke super will not contribute to progress".